### PR TITLE
Configurable search limit and correct primary key

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,43 @@ class ListMyResources extends ListRecords
 }
 ```
 
-The table defined in the resource needs to be `searchable()` as described in the [Filament table docs](https://filamentphp.com/docs/3.x/tables/advanced#searching-records-with-laravel-scout). Making each column searchable is not required anymore, as the content of what is searchable is defined within scout.
+The table defined in the resource needs to be `searchable()` as described in the [Filament table docs](https://filamentphp.com/docs/3.x/tables/advanced#searching-records-with-laravel-scout). 
+Making each column searchable is not required anymore, as the content of what is searchable is defined within scout.
+
+### Increase the number of search results
+
+Depending on the scout engine you may have limitations on how many search results you get back.
+This can be adjusted in two places:
+
+#### 1. Search Limit
+
+Add the following `env` variable to adjust the limit of search results:
+
+```
+SCOUT_SEARCH_LIMIT=100
+```
+
+`100` is the default value within this pagacke.
+For example meilisearch has a default limit of `20`.
+
+#### 2. Index Settings (Example for meilisearch)
+
+Within meilisearch there is a default limit of `1000` total hits which is also the upper bound for the search limit.
+That means if you want to have more than `1000` search results, you need to adapt both: the search limit and the index settings.
+The index settings can be adjusted within `config\scout.php`:
+
+```php
+'index-settings' => [
+  MyClass::class => [
+    'pagination' => [
+      'maxTotalHits' => 10000
+    ],
+  ],
+],
+```
+
+Then run the following command to sync the settings: `php artisan scout:sync-index-settings`
+
 
 ## Global Search
 

--- a/config/kainiklas-filament-scout.php
+++ b/config/kainiklas-filament-scout.php
@@ -1,0 +1,6 @@
+<?php
+
+// config for Kainiklas/FilamentScout
+return [
+    'search_limit' => env('SEARCH_LIMIT', 100),
+];

--- a/config/kainiklas-filament-scout.php
+++ b/config/kainiklas-filament-scout.php
@@ -2,5 +2,5 @@
 
 // config for Kainiklas/FilamentScout
 return [
-    'search_limit' => env('SEARCH_LIMIT', 100),
+    'scout_search_limit' => env('SCOUT_SEARCH_LIMIT', 100),
 ];

--- a/src/FilamentScoutServiceProvider.php
+++ b/src/FilamentScoutServiceProvider.php
@@ -24,6 +24,8 @@ class FilamentScoutServiceProvider extends PackageServiceProvider
                 $command
                     ->askToStarRepoOnGitHub('kainiklas/filament-scout');
             });
+
+        $package->hasConfigFile();
     }
 
     public function packageRegistered(): void

--- a/src/Traits/InteractsWithScout.php
+++ b/src/Traits/InteractsWithScout.php
@@ -16,14 +16,14 @@ trait InteractsWithScout
             return $query;
         }
 
-        $searchLimit = config('kainiklas-filament-scout.search_limit');
+        $searchLimit = config('kainiklas-filament-scout.scout_search_limit');
         $primaryKeyName = app($this->getModel())->getKeyName();
 
         $keys = $this->getModel()::search($search)
             ->query(function ($query) use ($primaryKeyName) {
                 $query->select($primaryKeyName);
             })
-            ->paginate($searchLimit, page: 1) // use first page, pagination is done later
+            ->paginate($searchLimit, page: 1) // stick with first page, pagination is done later by filament
             ->pluck($primaryKeyName);
 
         return $query->whereIn($primaryKeyName, $keys);

--- a/src/Traits/InteractsWithScout.php
+++ b/src/Traits/InteractsWithScout.php
@@ -16,8 +16,16 @@ trait InteractsWithScout
             return $query;
         }
 
-        $keys = $this->getModel()::search($search)->keys();
+        $searchLimit = config('kainiklas-filament-scout.search_limit');
+        $primaryKeyName = app($this->getModel())->getKeyName();
 
-        return $query->whereIn('id', $keys);
+        $keys = $this->getModel()::search($search)
+            ->query(function ($query) use ($primaryKeyName) {
+                $query->select($primaryKeyName);
+            })
+            ->paginate($searchLimit, page: 1) // use first page, pagination is done later
+            ->pluck($primaryKeyName);
+
+        return $query->whereIn($primaryKeyName, $keys);
     }
 }


### PR DESCRIPTION
Resolves Issue https://github.com/kainiklas/filament-scout/issues/10 

- A search limit for table search can be configured and is explicitly set on each search to avoid the 20 items limit from meilisearch
- The correct primary key from the model is used instead of id