### PR TITLE
InteractsWithScout: optimize queries

### DIFF
--- a/src/Traits/InteractsWithScout.php
+++ b/src/Traits/InteractsWithScout.php
@@ -17,15 +17,8 @@ trait InteractsWithScout
         }
 
         $searchLimit = config('kainiklas-filament-scout.scout_search_limit');
-        $primaryKeyName = app($this->getModel())->getKeyName();
+        $keys = $this->getModel()::search($search)->take($searchLimit)->keys();
 
-        $keys = $this->getModel()::search($search)
-            ->query(function ($query) use ($primaryKeyName) {
-                $query->select($primaryKeyName);
-            })
-            ->paginate($searchLimit, page: 1) // stick with first page, pagination is done later by filament
-            ->pluck($primaryKeyName);
-
-        return $query->whereIn($primaryKeyName, $keys);
+        return $query->whereKey($keys);
     }
 }


### PR DESCRIPTION
Currently the way search is implemented, there are four queries:

### Queries 1 + 2:

```php
$keys = $this->getModel()::search($search)
    ->query(function ($query) use ($primaryKeyName) {
        $query->select($primaryKeyName);
    })
    ->paginate($searchLimit, page: 1)
```

Scout's `paginate()` method performs two queries. Query no.1 is your query that fetches the models from the DB (that you optimized to only fetch the IDs), query no.2 is a `COUNT` query for the pagination class returned by the method, so that the user knows the total amount of records.

### Query 3:

Inside Filament's `CanPaginateRecords`, specifically the `getCountForPagination` method.
Using the search results, it fetches the total amount of models based on the results in query no.1 and other filters in the model

### Query 4:

```php
// InteractsWithScout's applySearchToTableQuery
return $query->whereIn($primaryKeyName, $keys);
```

The actual result fetch to display in the table

---

My changes get rid of queries 1+2 , by using Scout's `take()` and `keys()` methods - `keys()` doesn't perform any SQL queries, instead it simply returns the IDs from the search. Thus reducing the amount of queries to the original, minimum amount possible with Filament.

